### PR TITLE
feat: add new hostname configuration for external API access

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,8 @@ const nextConfig = withNextIntl({
             },
             {
                 hostname:'localhost'
+            },{
+                hostname:"be.cd-web.me"
             }
         ],
     },


### PR DESCRIPTION
This pull request adds a new hostname to the `next.config.ts` file to support additional environments.

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR12-R13): Added `"be.cd-web.me"` as a new hostname in the `nextConfig` configuration.